### PR TITLE
Improve support for Swift and Objective-C interlacing

### DIFF
--- a/Sources/GRDBObjcCore/FMDatabase.swift
+++ b/Sources/GRDBObjcCore/FMDatabase.swift
@@ -6,6 +6,9 @@ import Foundation
     let db: Database
     var dateFormatter: DateFormatter?
 
+    /// The GRDB database connection that fuels this FMDatabase instance.
+    public var grdbConnection: Database { return db }
+    
     init(_ db: Database) {
         self.db = db
         self.dateFormatter = nil

--- a/Tests/FMDatabaseQueueTests.swift
+++ b/Tests/FMDatabaseQueueTests.swift
@@ -26,5 +26,13 @@ class FMDatabaseQueueTests: GRDBObjcTestCase {
             XCTAssertEqual(int, 123)
         }
     }
-
+    
+    func testFMDatabaseExposesGRDBDatabase() throws {
+        let fmdbQueue = try FMDatabaseQueue(path: makeTemporaryDatabasePath())
+        fmdbQueue.inDatabase { (db: FMDatabase) in
+            // Use GRDB API from FMDatabase
+            let string = try! String.fetchOne(db.grdbConnection, "SELECT 'foo'")
+            XCTAssertEqual(string, "foo")
+        }
+    }
 }


### PR DESCRIPTION
FMDatabase now exposes its underlying GRDB connection, so that Objective-C can delegate database accesses to Swift:

```objc
// ObjC
- (void)doStuff:(FMDatabase *)db {
    [self doStuffWithSwift:db];
}
``` 

```swift
// Swift
@objc public func doStuffWithSwift(_ db: FMDatabase) {
    let db = db.grdbConnection
    // Proceed with regular GRDB apis
    ...
}
```
