### PR TITLE
Don't let statements outlive their execution

### DIFF
--- a/Sources/GRDBObjc/FMDatabase+Objc.m
+++ b/Sources/GRDBObjc/FMDatabase+Objc.m
@@ -63,14 +63,14 @@
     // @autoreleasepool asserts intermediate GRDB values are deinited on the
     // current (correct) thread.
     @autoreleasepool {
-        _FMSelectStatement *statement = [self _makeSelectStatement:sql error:outErr];
+        _FMSelectStatement *statement = [self _makeSelectStatement:sql error:&error];
         if (statement) {
             NSMutableArray *arguments = [NSMutableArray array];
             for(int i = sqlite3_bind_parameter_count(statement.sqliteHandle); i > 0; i--) {
                 id obj = va_arg(args, id);
                 [arguments addObject:obj ?: [NSNull null]];
             }
-            result = [statement executeWithValues:arguments error:outErr];
+            result = [statement executeWithValues:arguments error:&error];
         }
     }
     

--- a/Sources/GRDBObjc/FMDatabase+Objc.m
+++ b/Sources/GRDBObjc/FMDatabase+Objc.m
@@ -23,17 +23,19 @@
 
 - (BOOL)executeUpdate:(NSString * _Nonnull)sql va_list:(va_list)args error:(NSError **)outErr;
 {
-    _FMUpdateStatement *statement = [self _makeUpdateStatement:sql error:outErr];
-    if (!statement) {
-        return NO;
+    @autoreleasepool {
+        _FMUpdateStatement *statement = [self _makeUpdateStatement:sql error:outErr];
+        if (!statement) {
+            return NO;
+        }
+        
+        NSMutableArray *arguments = [NSMutableArray array];
+        for(int i = sqlite3_bind_parameter_count(statement.sqliteHandle); i > 0; i--) {
+            id obj = va_arg(args, id);
+            [arguments addObject:obj ?: [NSNull null]];
+        }
+        return [statement executeWithValues:arguments error:outErr];
     }
-    
-    NSMutableArray *arguments = [NSMutableArray array];
-    for(int i = sqlite3_bind_parameter_count(statement.sqliteHandle); i > 0; i--) {
-        id obj = va_arg(args, id);
-        [arguments addObject:obj ?: [NSNull null]];
-    }
-    return [statement executeWithValues:arguments error:outErr];
 }
 
 - (FMResultSet * _Nullable)executeQuery:(NSString * _Nonnull)sql, ...
@@ -47,17 +49,19 @@
 
 - (FMResultSet * _Nullable)executeQuery:(NSString * _Nonnull)sql va_list:(va_list)args error:(NSError **)outErr;
 {
-    _FMSelectStatement *statement = [self _makeSelectStatement:sql error:outErr];
-    if (!statement) {
-        return nil;
+    @autoreleasepool {
+        _FMSelectStatement *statement = [self _makeSelectStatement:sql error:outErr];
+        if (!statement) {
+            return nil;
+        }
+        
+        NSMutableArray *arguments = [NSMutableArray array];
+        for(int i = sqlite3_bind_parameter_count(statement.sqliteHandle); i > 0; i--) {
+            id obj = va_arg(args, id);
+            [arguments addObject:obj ?: [NSNull null]];
+        }
+        return [statement executeWithValues:arguments error:outErr];
     }
-    
-    NSMutableArray *arguments = [NSMutableArray array];
-    for(int i = sqlite3_bind_parameter_count(statement.sqliteHandle); i > 0; i--) {
-        id obj = va_arg(args, id);
-        [arguments addObject:obj ?: [NSNull null]];
-    }
-    return [statement executeWithValues:arguments error:outErr];
 }
 
 @end

--- a/Sources/GRDBObjc/FMDatabase+Objc.m
+++ b/Sources/GRDBObjc/FMDatabase+Objc.m
@@ -23,19 +23,27 @@
 
 - (BOOL)executeUpdate:(NSString * _Nonnull)sql va_list:(va_list)args error:(NSError **)outErr;
 {
+    BOOL result = NO;
+    NSError *error = nil;
+    
+    // @autoreleasepool asserts intermediate GRDB values are deinited on the
+    // current (correct) thread.
     @autoreleasepool {
-        _FMUpdateStatement *statement = [self _makeUpdateStatement:sql error:outErr];
-        if (!statement) {
-            return NO;
+        _FMUpdateStatement *statement = [self _makeUpdateStatement:sql error:&error];
+        if (statement) {
+            NSMutableArray *arguments = [NSMutableArray array];
+            for(int i = sqlite3_bind_parameter_count(statement.sqliteHandle); i > 0; i--) {
+                id obj = va_arg(args, id);
+                [arguments addObject:obj ?: [NSNull null]];
+            }
+            result = [statement executeWithValues:arguments error:&error];
         }
-        
-        NSMutableArray *arguments = [NSMutableArray array];
-        for(int i = sqlite3_bind_parameter_count(statement.sqliteHandle); i > 0; i--) {
-            id obj = va_arg(args, id);
-            [arguments addObject:obj ?: [NSNull null]];
-        }
-        return [statement executeWithValues:arguments error:outErr];
     }
+    
+    if (result) { return result; }
+    NSParameterAssert(error);
+    if (outErr != NULL) { *outErr = error; }
+    return NO;
 }
 
 - (FMResultSet * _Nullable)executeQuery:(NSString * _Nonnull)sql, ...
@@ -49,19 +57,27 @@
 
 - (FMResultSet * _Nullable)executeQuery:(NSString * _Nonnull)sql va_list:(va_list)args error:(NSError **)outErr;
 {
+    FMResultSet *result = nil;
+    NSError *error = nil;
+    
+    // @autoreleasepool asserts intermediate GRDB values are deinited on the
+    // current (correct) thread.
     @autoreleasepool {
         _FMSelectStatement *statement = [self _makeSelectStatement:sql error:outErr];
-        if (!statement) {
-            return nil;
+        if (statement) {
+            NSMutableArray *arguments = [NSMutableArray array];
+            for(int i = sqlite3_bind_parameter_count(statement.sqliteHandle); i > 0; i--) {
+                id obj = va_arg(args, id);
+                [arguments addObject:obj ?: [NSNull null]];
+            }
+            result = [statement executeWithValues:arguments error:outErr];
         }
-        
-        NSMutableArray *arguments = [NSMutableArray array];
-        for(int i = sqlite3_bind_parameter_count(statement.sqliteHandle); i > 0; i--) {
-            id obj = va_arg(args, id);
-            [arguments addObject:obj ?: [NSNull null]];
-        }
-        return [statement executeWithValues:arguments error:outErr];
     }
+    
+    if (result) { return result; }
+    NSParameterAssert(error);
+    if (outErr != NULL) { *outErr = error; }
+    return nil;
 }
 
 @end


### PR DESCRIPTION
This PR avoids unexpected statement deallocations postponed on some thread that is not allowed to access the database.
